### PR TITLE
fix: do not add aria-describedby to hidden inputs

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -328,6 +328,7 @@ class Abide extends Plugin {
   }
 
   addA11yErrorDescribe($el, $error) {
+    if ($el.attr('type') === 'hidden') return;
     if (typeof $el.attr('aria-describedby') !== 'undefined') return;
 
     // Set [aria-describedby] on the input toward the first form error if it is not set

--- a/test/javascript/components/abide.js
+++ b/test/javascript/components/abide.js
@@ -157,6 +157,19 @@ describe('Abide', function() {
       $html.find('input').should.not.have.attr('aria-describedby', 'test-error');
     });
 
+    it('does not add [aria-describedby] to the field if the input is hidden', function() {
+      $html = $(`
+        <form data-abide>
+          <input type="hidden" id="test-input">
+          <span class="form-error is-visible" id="test-error">Form error</span>
+        </form>
+      `).appendTo('body');
+      plugin = new Foundation.Abide($html, {});
+      plugin.addA11yAttributes($html.find('input'));
+
+      $html.find('input').should.not.have.attr('aria-describedby', 'test-error');
+    });
+
     it('adds [aria-describedby] to the field if the form error is shown after a validation error', function() {
       $html = $(`
         <form data-abide>


### PR DESCRIPTION
## Description
The abide component is currently potentially adding the `aria-describedby` attribute also on hidden inputs where it is not valid HTML.

The intention of the HTML validator is not to allow this through this rule:
https://github.com/validator/validator/blob/b896708d94d12df67075c6cfd43afc0f8a140ef0/src/nu/validator/checker/schematronequiv/Assertions.java#L2042-L2045

However, currently it is buggy and the following HTML passes the [HTML validator](https://validator.w3.org/nu/#textarea):

```html
<!DOCTYPE html>
<html lang="">
<head>
  <title>Test</title>
</head>
<body>
  <form>
    <input type="hidden" name="test" value="abc" aria-describedby="test-abide-error">
    <span id="test-abide-error">Test</span>
  </form>
</body>
</html>
```

But this fix will fix it also in the future versions of the HTML validator when that bug is fixed.

## Types of changes

- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist

- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).